### PR TITLE
fix compilation for i686-apple-darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-mach = "0.0.5"
+mach = "0.1.1"
 CoreFoundation-sys = "0.1.3"

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@
 use libc::{c_char,c_int,c_uint};
 
 use mach::port::mach_port_t;
-use mach::vm_types::mach_vm_address_t;
+use mach::vm_types::{mach_vm_address_t, mach_vm_size_t, vm_address_t};
 
 pub type IOOptionBits = u32;
 pub type IOFixed      = i32;


### PR DESCRIPTION
There were some typo or missing use statements for the compilation for i686-apple-darwin to succeed.

Fixes #4 