### PR TITLE
IONotificationPortGetRunLoopSource function & notification keys

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -5,3 +5,18 @@ use libc::{c_char};
 pub fn kIOServiceClass() -> *const c_char {
     b"IOService\0".as_ptr() as *const c_char
 }
+pub fn kIOPublishNotification() -> *const c_char{
+	b"IOServicePublish\0".as_ptr() as *const c_char
+}
+pub fn kIOFirstPublishNotification() -> *const c_char{
+	b"IOServiceFirstPublish\0".as_ptr() as *const c_char
+}
+pub fn kIOMatchedNotification() -> *const c_char{
+	b"IOServiceMatched\0".as_ptr() as *const c_char
+}
+pub fn kIOFirstMatchNotification() -> *const c_char{
+	b"IOServiceFirstMatch\0".as_ptr() as *const c_char
+}
+pub fn kIOTerminatedNotification() -> *const c_char{
+	b"IOServiceTerminate\0".as_ptr() as *const c_char
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate CoreFoundation_sys as cf;
 extern crate libc;
 extern crate mach;
 
-use cf::{CFTypeRef,CFDictionaryRef,CFMutableDictionaryRef,CFStringRef,CFAllocatorRef};
+use cf::{CFTypeRef,CFDictionaryRef,CFMutableDictionaryRef,CFStringRef,CFAllocatorRef,CFRunLoopSourceRef};
 use libc::{c_void,c_char,c_int,size_t,uintptr_t};
 
 use mach::boolean::boolean_t;
@@ -63,6 +63,7 @@ extern "C" {
 
     pub fn IONotificationPortCreate(masterPort: mach_port_t) -> IONotificationPortRef;
     pub fn IONotificationPortDestroy(notify: IONotificationPortRef);
+	pub fn IONotificationPortGetRunLoopSource(notify: IONotificationPortRef) -> CFRunLoopSourceRef;
     pub fn IONotificationPortGetMachPort(notify: IONotificationPortRef) -> mach_port_t;
 
     pub fn IOCreateReceivePort(msgType: u32, recvPort: *mut mach_port_t) -> kern_return_t;


### PR DESCRIPTION
This adds a foreign function declaration for `IONotificationPortGetRunLoopSource()` as well as C-string "constants" (as functions, same as other IOKit string constants) to be used with `IOServiceAddMatchingNotification()`.