### PR TITLE
Replace CoreFoudnation-sys with core-foundation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 mach = "0.1.1"
-CoreFoundation-sys = "0.1.4"
+core-foundation = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "IOKit-sys"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>"]
 description = "FFI bindings for IOKit"
 license = "MIT"

--- a/examples/list_serial_ports.rs
+++ b/examples/list_serial_ports.rs
@@ -1,5 +1,5 @@
 extern crate IOKit_sys;
-extern crate CoreFoundation_sys as cf;
+extern crate core_foundation as cf;
 extern crate libc;
 extern crate mach;
 
@@ -14,7 +14,7 @@ use mach::port::{mach_port_t,MACH_PORT_NULL};
 use mach::kern_return::KERN_SUCCESS;
 
 use IOKit_sys::*;
-use cf::*;
+use cf::{base::*, string::*, dictionary::*};
 
 
 fn main() {
@@ -64,7 +64,7 @@ fn main() {
 
             let result = IORegistryEntryCreateCFProperties(modem_service, &mut props, kCFAllocatorDefault, 0);
             if result == KERN_SUCCESS {
-                CFDictionaryApplyFunction(props, print_property_entry, ptr::null());
+                CFDictionaryApplyFunction(props, print_property_entry, ptr::null_mut());
             }
 
             IOObjectRelease(modem_service);
@@ -72,7 +72,7 @@ fn main() {
     }
 }
 
-extern "C" fn print_property_entry(key: CFTypeRef, value: CFTypeRef, _context: *const c_void) {
+extern "C" fn print_property_entry(key: CFTypeRef, value: CFTypeRef, _context: *mut c_void) {
     unsafe {
         let mut buf = Vec::<c_char>::with_capacity(256);
 

--- a/src/io_hid_base.rs
+++ b/src/io_hid_base.rs
@@ -1,7 +1,7 @@
 // exports from <IOKit/hid/IOHIDBase.h>
 
 use libc::c_void;
-use cf::CFIndex;
+use cf::base::CFIndex;
 use io_return::IOReturn;
 use io_hid_keys::IOHIDReportType;
 

--- a/src/io_hid_manager.rs
+++ b/src/io_hid_manager.rs
@@ -1,7 +1,7 @@
 // exports from <IOKit/hid/IOHIDManager.h>
 
 use libc::c_void;
-use cf::{CFAllocatorRef, CFDictionaryRef};
+use cf::{base::CFAllocatorRef, dictionary::CFDictionaryRef};
 use types::IOOptionBits;
 use io_return::IOReturn;
 use io_hid_base::{IOHIDDeviceCallback, IOHIDReportCallback};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 #![allow(non_camel_case_types,non_upper_case_globals,non_snake_case)]
 
-extern crate CoreFoundation_sys as cf;
+extern crate core_foundation as cf;
 extern crate libc;
 extern crate mach;
 
-use cf::{CFTypeRef,CFDictionaryRef,CFMutableDictionaryRef,CFStringRef,CFAllocatorRef};
+use cf::{base::CFTypeRef,dictionary::CFDictionaryRef,dictionary::CFMutableDictionaryRef,string::CFStringRef,base::CFAllocatorRef};
 use libc::{c_void,c_char,c_int,size_t,uintptr_t};
 
 use mach::boolean::boolean_t;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ mod io_hid_manager;
 pub struct IONotificationPort {
     __private: c_void,
 }
-
 pub type IONotificationPortRef = *mut IONotificationPort;
 
 pub type IOServiceMatchingCallback = extern fn (refcon: *mut c_void, iterator: io_iterator_t);
@@ -63,6 +62,7 @@ extern "C" {
 
     pub fn IONotificationPortCreate(masterPort: mach_port_t) -> IONotificationPortRef;
     pub fn IONotificationPortDestroy(notify: IONotificationPortRef);
+    pub fn IONotificationPortGetRunLoopSource(notify: IONotificationPortRef) -> cf::runloop::CFRunLoopSourceRef;
     pub fn IONotificationPortGetMachPort(notify: IONotificationPortRef) -> mach_port_t;
 
     pub fn IOCreateReceivePort(msgType: u32, recvPort: *mut mach_port_t) -> kern_return_t;


### PR DESCRIPTION
It seems that `CoreFoundation-sys` is not as actively maintained as `core-foundation` with the latter being used in Mozilla's Servo. So I've gone ahead and migrated over to it. And I've added `IONotificationPortGetRunLoopSource` as I needed it.
I have bumped the version number as this isn't a backwards compatible change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcuddeback/iokit-sys/10)
<!-- Reviewable:end -->
