### PR TITLE
Draft: migrate from mach to mach2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-mach = "0.1.1"
+mach2 = "0.4"
 CoreFoundation-sys = "0.1.4"

--- a/examples/list_serial_ports.rs
+++ b/examples/list_serial_ports.rs
@@ -1,7 +1,7 @@
 extern crate IOKit_sys;
 extern crate CoreFoundation_sys as cf;
 extern crate libc;
-extern crate mach;
+extern crate mach2;
 
 use std::mem;
 use std::ptr;
@@ -10,8 +10,8 @@ use std::ffi::{CString,CStr};
 
 use libc::{c_char,c_void};
 
-use mach::port::{mach_port_t,MACH_PORT_NULL};
-use mach::kern_return::KERN_SUCCESS;
+use mach2::port::{mach_port_t,MACH_PORT_NULL};
+use mach2::kern_return::KERN_SUCCESS;
 
 use IOKit_sys::*;
 use cf::*;

--- a/src/io_return.rs
+++ b/src/io_return.rs
@@ -1,6 +1,6 @@
 // exports from <IOKit/IOReturn.h>
 
-use mach::kern_return::{kern_return_t,KERN_SUCCESS};
+use mach2::kern_return::{kern_return_t,KERN_SUCCESS};
 
 pub type IOReturn = kern_return_t;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,12 @@ extern crate mach;
 use cf::{CFTypeRef,CFDictionaryRef,CFMutableDictionaryRef,CFStringRef,CFAllocatorRef};
 use libc::{c_void,c_char,c_int,size_t,uintptr_t};
 
-use mach::boolean::boolean_t;
-use mach::clock_types::mach_timespec_t;
-use mach::kern_return::kern_return_t;
-use mach::port::mach_port_t;
-use mach::types::task_port_t;
-use mach::vm_types::{mach_vm_address_t,mach_vm_size_t};
+use mach2::boolean::boolean_t;
+use mach2::clock_types::mach_timespec_t;
+use mach2::kern_return::kern_return_t;
+use mach2::port::mach_port_t;
+use mach2::types::task_port_t;
+use mach2::vm_types::{mach_vm_address_t,mach_vm_size_t};
 
 pub use io_return::*;
 pub use keys::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,11 +2,11 @@
 
 use libc::{c_char,c_int,c_uint};
 
-use mach::port::mach_port_t;
-use mach::vm_types::mach_vm_address_t;
+use mach2::port::mach_port_t;
+use mach2::vm_types::mach_vm_address_t;
 
 #[cfg(target_pointer_width = "32")]
-use mach::vm_types::{mach_vm_size_t, vm_address_t};
+use mach2::vm_types::{mach_vm_size_t, vm_address_t};
 
 pub type IOOptionBits = u32;
 pub type IOFixed      = i32;


### PR DESCRIPTION
According to RUSTSEC-2020-0168 [1] mach is unmaintained and mach2 is the "go-to" alternative. Therefore migrate to mach2.

To fully remove the mach dependency https://github.com/dcuddeback/core-foundation-sys/pull/10 needs to be merged and CoreFoundation-sys needs to be updated in our Cargo.toml.

[1] https://github.com/heim-rs/heim/issues/367